### PR TITLE
Fixed deadlock when starting server with a SecretBlock in the spawn chunks

### DIFF
--- a/src/main/java/com/wynprice/secretrooms/server/blocks/SecretBaseBlock.java
+++ b/src/main/java/com/wynprice/secretrooms/server/blocks/SecretBaseBlock.java
@@ -37,6 +37,7 @@ import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -366,8 +367,19 @@ public class SecretBaseBlock extends Block implements IWaterLoggable {
         if(world == null || pos == null) {
             return Optional.empty();
         }
+
+        BlockState blockState = null;
+        if (world instanceof World) {
+            Chunk chunk = ((World) world).getChunkProvider().getChunkNow(pos.getX() >> 4, pos.getZ() >> 4);
+            if (chunk != null) {
+                blockState = chunk.getBlockState(pos);
+            }
+        } else {
+            blockState = world.getBlockState(pos);
+        }
+
         TileEntity te = world.getTileEntity(pos);
-        return world.getBlockState(pos).getBlock() instanceof SecretBaseBlock && te instanceof SecretTileEntity ?
+        return blockState != null && blockState.getBlock() instanceof SecretBaseBlock && te instanceof SecretTileEntity ?
             Optional.of(((SecretTileEntity) te).getData()) : Optional.empty();
     }
 

--- a/src/main/java/com/wynprice/secretrooms/server/blocks/SecretBaseBlock.java
+++ b/src/main/java/com/wynprice/secretrooms/server/blocks/SecretBaseBlock.java
@@ -368,6 +368,7 @@ public class SecretBaseBlock extends Block implements IWaterLoggable {
             return Optional.empty();
         }
 
+        // Fixes a deadlock that occurs when there is a SecretBlock in a spawn chunk (see https://github.com/Wyn-Price/SecretRooms/pull/53)
         BlockState blockState = null;
         if (world instanceof World) {
             Chunk chunk = ((World) world).getChunkProvider().getChunkNow(pos.getX() >> 4, pos.getZ() >> 4);


### PR DESCRIPTION
This pull request aims to fix the following bug:

A secret block in spawn chunks (in my case it was a chunk, that was loaded by a chunk force loading mod),
will try to get a blockstate from a chunk, but in this specific case, the call won't return, ever.

(I didn't investigate this further, but the only explanation I can come up with, is that the main thread waits for the mods to finish, and the getChunk call has to be executed by the main thread, thus they both wait for each other)

Screenshot of the bug (from VisualVM)
https://i.imgur.com/Rivn0Aa.png